### PR TITLE
add optional node selector

### DIFF
--- a/helm/gatling-app/templates/job.yaml
+++ b/helm/gatling-app/templates/job.yaml
@@ -57,3 +57,7 @@ spec:
           name: {{ .Values.simulation.configMap.name }}
           optional: true
       {{- end }}
+{{- if .Values.nodeAffinity.enabled }}
+      nodeSelector:
+        {{- toYaml .Values.nodeAffinity.selector | nindent 8 }}
+{{- end }}

--- a/helm/gatling-app/values.yaml
+++ b/helm/gatling-app/values.yaml
@@ -46,3 +46,9 @@ simulation:
   # be hosted at an accessible location. If provided then it
   # overrides any simulation configMaps.
   url: ""
+
+# Enable and give a proper NodeSelector to run the simulation on
+# a specific cluster node.
+nodeAffinity:
+  enabled: false
+  selector: {}


### PR DESCRIPTION
Required to make sure that during testing gatling is not running on the same node as the application under test.