### PR TITLE
Fix ATS issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Move labels to _helpers.tpl ([#67](https://github.com/giantswarm/gatling-app/pull/67))
 
+### Fixed
+
+- ATS failing to run
+
 ## [v1.0.0] 2020-05-28
 
 ### Added


### PR DESCRIPTION
This PR is created to investigate why app-test-suite is failing.

Running ats on a local kind cluster with ```./dats.sh -c gatling-app-1.0.2-ac60ddc49c3b5e16ff051c80484c23cdaac55374.tgz --smoke-tests-cluster-type kind```.

Output from `kubectl get apps gatling-app -o yaml`:

```piVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  creationTimestamp: "2022-05-05T12:26:11Z"
  finalizers:
  - operatorkit.giantswarm.io/app-operator-app
  generation: 1
  labels:
    app: gatling-app
    app-operator.giantswarm.io/version: 0.0.0
  name: gatling-app
  namespace: default
  resourceVersion: "1053"
  uid: 07c4eb73-4146-47ec-8994-7aa87a3dcba3
spec:
  catalog: chartmuseum
  catalogNamespace: default
  kubeConfig:
    inCluster: true
  name: gatling-app
  namespace: default
  namespaceConfig:
    annotations: {}
    labels: {}
  version: 1.0.2-ac60ddc49c3b5e16ff051c80484c23cdaac55374
status:
  appVersion: ""
  release:
    lastDeployed: null
    reason: 'Upgrade "gatling-app" failed: failed to create resource: Job.batch "gatling"
      is invalid: [spec.template.spec.volumes[0].configMap.name: Required value, spec.template.spec.containers[0].volumeMounts[0].name:
      Not found: "simulationdir"]'
    status: failed
  version: ""```