### PR TITLE
Do not install PSP if apiVersion not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
 - Values: Rename `nginx-ingress-controller` to `ingress-nginx`. ([#123](https://github.com/giantswarm/gatling-app/pull/123))
+- Do not install PodSecurityPolicy if api not available.
 
 ## [2.0.3] - 2023-04-03
 

--- a/helm/gatling-app/templates/podsecuritypolicy.yaml
+++ b/helm/gatling-app/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -34,3 +35,4 @@ spec:
   allowPrivilegeEscalation: false
   seLinux:
     rule: RunAsAny
+{{- end }}


### PR DESCRIPTION
This PR changes the helm templates to not install PodSecurityPolicies if their apiVersion is not available.

Towards giantswarm/giantswarm#23400